### PR TITLE
Moved powerline and added pane highlight

### DIFF
--- a/.tmux.conf.local
+++ b/.tmux.conf.local
@@ -11,3 +11,10 @@ set-option -g status-left-length 60
 set-option -g status-right-length 90
 set-option -g status-left "#(~/Documents/github/tmux-powerline/powerline.sh left)"
 set-option -g status-right "#(~/Documents/github/tmux-powerline/powerline.sh right)"
+
+# move the powerline to the top
+set -g status-position top
+
+# highlight the active pane
+set -g pane-active-border-fg brightblue
+


### PR DESCRIPTION
+ Powerline has been moved to the top. Makes it easier to see the time, and doesnt get mixed with the vim powerline
+ The active pane now has a highlight around it